### PR TITLE
Adjust project name and update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
-# FluxSimulator
+# pyarts-fluxes
 
-Convenience scripts for calculating radiative fluxes with ARTS
+Python module for calculating radiative fluxes with ARTS.
+The module is an easy-to-use wrapper to calculate radiative fluxes with ARTS.
+The idea behind is to prepare a basic setup so that the user can easily calculate radiative fluxes with ARTS without having to deal with the actual ARTS simulation setup.
+Expierenceed users can still access the ARTS workspace and modify it as they like.
 
 Get ARTS (pyarts): https://radiativetransfer.org/getarts/
 
 ## Requirements
 
-FluxSimulator requires the following Python packages:
+pyarts-fluxes requires the following Python packages:
 
 - pyarts >=2.6.2
 
 ## Installation
 
-To install FluxSimulator, clone the repository and run the setup script:
+To install pyarts-fluxes, clone the repository and run the setup script:
 
 ```bash
-git clone https://github.com/m-brath/FluxSimulator.git
-cd FluxSimulator
+git clone https://github.com/atmtools/pyarts-fluxes
+cd pyarts-fluxes
 python -m pip install --user -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "FluxSimulator"
 version = "0.1"
 dependencies = [
-  "numpy"  
+  "numpy, matplotlib"  
 ]
 requires-python = ">= 3.9"
 authors = [
@@ -11,7 +11,7 @@ authors = [
 maintainers = [
   {name = "Manfred Brath", email = "manfred.brath@uni-hamburg.de"}
 ]
-description = "Convenience functions for simulating fluxes with ARTS."
+description = "Easy-to-use wrapper to calculate radiative fluxes with ARTS."
 readme = "readme.md"
 
 [project.urls]


### PR DESCRIPTION
The project name has been adjusted from "FluxSimulator" to "pyarts-fluxes" to better reflect its purpose. Additionally, the description has been updated to clarify that the module is a wrapper for calculating radiative fluxes with ARTS and to provide information on how to install it.